### PR TITLE
Treat usage help as literal text, closes issue 18

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -520,7 +520,7 @@ request_certificate(){
 }
 
 usage() {
-    cat << EOT
+    cat << 'EOT'
 letsencrypt.sh register [-p] -a account_key -e email
 letsencrypt.sh thumbprint -a account_key
 letsencrypt.sh sign -a account_key -k server_key -c signed_crt domain ...


### PR DESCRIPTION
Fix to expanded empty variable help text: https://github.com/gheift/letsencrypt.sh/issues/18
